### PR TITLE
Cache control cli tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +296,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f807b2943dc90f9747497d9d65d7e92472149be0b88bf4ce1201b4ac979c26"
+dependencies = [
+ "console",
+ "lazy_static",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +327,12 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "eyre"
@@ -358,6 +392,7 @@ dependencies = [
  "chrono",
  "config",
  "ctrlc",
+ "dialoguer",
  "eyre",
  "fern",
  "futures",
@@ -1516,6 +1551,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +1933,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,3 +1961,9 @@ checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
 dependencies = [
  "linked-hash-map 0.5.3",
 ]
+
+[[package]]
+name = "zeroize"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ openssl-probe = "0.1.2"
 #sqlx = { path="../sqlx", features = [ "runtime-tokio-native-tls", "sqlite" ] }
 url = "2.1.1"
 sys-info = "0.7.0"
+dialoguer = "0.7.1"
 
 [dependencies.sqlx]
 git = "https://github.com/adorton-adobe/sqlx"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -14,6 +14,7 @@ use sqlx::{
     Row,
 };
 use std::sync::Arc;
+use dialoguer::Confirm;
 
 #[derive(Default)]
 pub struct Cache {
@@ -52,7 +53,7 @@ impl Cache {
     }
 
     pub async fn control(
-        &self, clear: Option<bool>, export_file: Option<String>,
+        &self, clear: bool, yes: bool, export_file: Option<String>,
         import_file: Option<String>,
     ) -> Result<(), sqlx::Error> {
         if !self.enabled {
@@ -70,13 +71,20 @@ impl Cache {
             println!("cache-control: Requesting export of cache to '{}'", path);
             eprintln!("cache-control: Export of cache not yet supported, sorry");
         }
-        if let Some(clear) = clear {
-            if clear {
+        if clear {
+            let confirm = match yes {
+                true => true,
+                false => Confirm::new()
+                        .with_prompt("Really clear the cache? This operation cannot be undone.")
+                        .default(false)
+                        .show_default(true)
+                        .interact()
+                        .unwrap(),
+            };
+            if confirm {
                 sqlx::query(CLEAR_ALL).execute(pool).await?;
                 println!("cache-control: Cache has been cleared.");
                 info!("Cache at '{}' has been cleared", db_name);
-            } else {
-                eprintln!("cache-control: To clear the cache, use --clear yes");
             }
         }
         Ok(())

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,13 +8,13 @@ it.
 */
 use crate::cops::{Kind, Request as CRequest, Response as CResponse};
 use crate::settings::Settings;
+use dialoguer::Confirm;
 use log::{debug, error, info};
 use sqlx::{
     sqlite::{SqlitePool, SqlitePoolOptions},
     Row,
 };
 use std::sync::Arc;
-use dialoguer::Confirm;
 
 #[derive(Default)]
 pub struct Cache {
@@ -75,11 +75,13 @@ impl Cache {
             let confirm = match yes {
                 true => true,
                 false => Confirm::new()
-                        .with_prompt("Really clear the cache? This operation cannot be undone.")
-                        .default(false)
-                        .show_default(true)
-                        .interact()
-                        .unwrap(),
+                    .with_prompt(
+                        "Really clear the cache? This operation cannot be undone.",
+                    )
+                    .default(false)
+                    .show_default(true)
+                    .interact()
+                    .unwrap(),
             };
             if confirm {
                 sqlx::query(CLEAR_ALL).execute(pool).await?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,10 @@ pub enum Opt {
         /// Path to optional config file
         config_file: Option<String>,
 
+        #[structopt(short = "C", long)]
+        /// Path to cache file
+        cache_file: Option<String>,
+
         #[structopt(long)]
         /// Whether to clear the cache (dangerous!)
         clear: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,14 +55,20 @@ pub enum Opt {
         /// Path to optional config file
         config_file: Option<String>,
 
-        #[structopt(long, parse(try_from_str = parse_bool))]
+        #[structopt(long)]
         /// Whether to clear the cache (dangerous!)
-        clear: Option<bool>,
+        clear: bool,
+
+        #[structopt(short)]
+        /// Bypass confirmation prompts
+        yes: bool,
 
         #[structopt(short, long)]
+        /// Export cache to a file (not yet implemented)
         export_file: Option<String>,
 
         #[structopt(short, long)]
+        /// Import cache from a file (not yet implemented)
         import_file: Option<String>,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,12 +64,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
         cli::Opt::CacheControl {
             config_file,
+            cache_file,
             clear,
             yes,
             export_file,
             import_file,
         } => {
-            let mut conf = Settings::from_cache_control(config_file)?;
+            let mut conf = Settings::from_cache_control(config_file, cache_file)?;
             conf.validate()?;
             let cache = Cache::new_from(&conf).await?;
             Cache::control(&cache, clear, yes, export_file, import_file).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,13 +65,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         cli::Opt::CacheControl {
             config_file,
             clear,
+            yes,
             export_file,
             import_file,
         } => {
             let mut conf = Settings::from_cache_control(config_file)?;
             conf.validate()?;
             let cache = Cache::new_from(&conf).await?;
-            Cache::control(&cache, clear, export_file, import_file).await?;
+            Cache::control(&cache, clear, yes, export_file, import_file).await?;
             debug!("conf: {:?}", conf);
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -77,7 +77,9 @@ impl Settings {
         s.try_into()
     }
 
-    pub fn from_cache_control(config_file: Option<String>, cache_file: Option<String>) -> Result<Self, ConfigError> {
+    pub fn from_cache_control(
+        config_file: Option<String>, cache_file: Option<String>,
+    ) -> Result<Self, ConfigError> {
         let mut s = Config::new();
         s.merge(ConfigFile::from_str(
             include_str!("res/defaults.toml"),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -77,7 +77,7 @@ impl Settings {
         s.try_into()
     }
 
-    pub fn from_cache_control(config_file: Option<String>) -> Result<Self, ConfigError> {
+    pub fn from_cache_control(config_file: Option<String>, cache_file: Option<String>) -> Result<Self, ConfigError> {
         let mut s = Config::new();
         s.merge(ConfigFile::from_str(
             include_str!("res/defaults.toml"),
@@ -85,6 +85,9 @@ impl Settings {
         ))?;
         if let Some(filename) = config_file {
             s.merge(ConfigFile::with_name(filename.as_str()))?;
+        }
+        if let Some(cache_file) = cache_file {
+            s.set("cache.cache_file_path", cache_file)?;
         }
         // force enablement of the cache if doing cache control
         s.set("proxy.mode", "cache")?;


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* Add `-C/--cache-file` option to `cache-control` so we don't need to depend on a config file
* Document import/export cache control CLI options
* Changed `--clear` to be a real bool flag instead of bool-like option
* Added an interactive confirmation prompt before executing cache clear. Prompt can be bypassed with `-y` flag

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Run `./frl-proxy cache-control -h` to see that `--clear` is a flag and `import`/`export` are documented
* Running `./frl-proxy cache-control --clear` will prompt for confirmation
* Running `./frl-proxy cache-control --clear -y` will bypass prompt and clear cache
* Specify `--cache-file <filename>` to either override `cache.cache_file_path` from config or use cache control command without a config file

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #7 (and thus fixes #5, which is included in #7).
