### PR TITLE
Implement --cache-file option for start mode

### DIFF
--- a/.changelog/changelog.md
+++ b/.changelog/changelog.md
@@ -10,6 +10,8 @@ Feature summary:
   * `forward` - execute all licensing activation and deactivation requests with licensing service and cache response data
 * `cache-control` command - manage the cache database
   * `--clear` - clear a cache database
+* `cache.cache_file_path` added to config file to specify cache DB file path
+  * Can be overridden from command-line with `-C/--config-file`
 * SSL cert now authenticated with password instead of key
 
 ---

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
+    -C, --cache-file <cache-file>        Path to cache file
     -c, --config-file <config-file>      Path to optional config file
         --host <host>                    Proxy hostname
     -m, --mode <mode>                    Mode to run the proxy in, one of passthrough, cache, store, or forward. You can

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,10 @@ pub enum Opt {
         /// You can use any prefix of these names (minimally p, c, s, or f)
         mode: Option<String>,
 
+        #[structopt(short = "C", long)]
+        /// Path to cache file
+        cache_file: Option<String>,
+
         #[structopt(long)]
         /// Proxy hostname
         host: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         cli::Opt::Start {
             config_file,
             mode,
+            cache_file,
             host,
             remote_host,
             ssl,
@@ -40,6 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             let mut conf = Settings::from_start(
                 config_file,
                 mode,
+                cache_file,
                 host,
                 remote_host,
                 ssl,

--- a/src/res/template.toml
+++ b/src/res/template.toml
@@ -16,4 +16,5 @@ file_log_path = "frl-proxy.log"
 
 [cache]
 # Cache settings
+# cache_file_path is overidden by --cache-file <filename>
 #cache_file_path = "frl-proxy.cache"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -44,9 +44,9 @@ pub struct Settings {
 
 impl Settings {
     pub fn from_start(
-        config_file: Option<String>, mode: Option<String>, host: Option<String>,
-        remote_host: Option<String>, ssl: Option<bool>, ssl_cert: Option<String>,
-        ssl_key: Option<String>,
+        config_file: Option<String>, mode: Option<String>, cache_file: Option<String>,
+        host: Option<String>, remote_host: Option<String>, ssl: Option<bool>,
+        ssl_cert: Option<String>, ssl_key: Option<String>,
     ) -> Result<Self, ConfigError> {
         let mut s = Config::new();
         s.merge(ConfigFile::from_str(
@@ -58,6 +58,9 @@ impl Settings {
         }
         if let Some(mode) = mode {
             s.set("proxy.mode", mode)?;
+        }
+        if let Some(cache_file) = cache_file {
+            s.set("cache.cache_file_path", cache_file)?;
         }
         if let Some(host) = host {
             s.set("proxy.host", host)?;


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* Add CLI option for `start` command to specify cache file path
* Note in config template that CLI option overrides config option (we should do this for the `proxy` options at some point)
* Readme reflects new interface

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Start proxy in non-`passthrough` mode without pointing to cache file and pass `-C/--cache-file` - e.g. `./frl-proxy start -m cache -C /path/to/cache.db`

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #5 
