### PR TITLE
Move to sqlx master tag, rather than forked repo.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,7 +1310,6 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
- "indexmap",
  "itoa",
  "ryu",
  "serde 1.0.118",
@@ -1386,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "sqlx"
 version = "0.4.2"
-source = "git+https://github.com/adorton-adobe/sqlx?branch=tokio-1.0#bb3992c8bf127b7cf9037132b45cf6eb0f7dc0af"
+source = "git+https://github.com/launchbadge/sqlx?branch=master#31abe22e348d6ac668c140de32612f0930c2abec"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -1395,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "sqlx-core"
 version = "0.4.2"
-source = "git+https://github.com/adorton-adobe/sqlx?branch=tokio-1.0#bb3992c8bf127b7cf9037132b45cf6eb0f7dc0af"
+source = "git+https://github.com/launchbadge/sqlx?branch=master#31abe22e348d6ac668c140de32612f0930c2abec"
 dependencies = [
  "ahash 0.6.2",
  "atoi",
@@ -1434,17 +1433,14 @@ dependencies = [
 [[package]]
 name = "sqlx-macros"
 version = "0.4.2"
-source = "git+https://github.com/adorton-adobe/sqlx?branch=tokio-1.0#bb3992c8bf127b7cf9037132b45cf6eb0f7dc0af"
+source = "git+https://github.com/launchbadge/sqlx?branch=master#31abe22e348d6ac668c140de32612f0930c2abec"
 dependencies = [
  "dotenv",
  "either",
  "futures",
  "heck",
- "once_cell",
  "proc-macro2",
  "quote",
- "serde 1.0.118",
- "serde_json",
  "sha2",
  "sqlx-core",
  "sqlx-rt",
@@ -1455,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "sqlx-rt"
 version = "0.2.0"
-source = "git+https://github.com/adorton-adobe/sqlx?branch=tokio-1.0#bb3992c8bf127b7cf9037132b45cf6eb0f7dc0af"
+source = "git+https://github.com/launchbadge/sqlx?branch=master#31abe22e348d6ac668c140de32612f0930c2abec"
 dependencies = [
  "native-tls",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ sys-info = "0.7.0"
 dialoguer = "0.7.1"
 
 [dependencies.sqlx]
-git = "https://github.com/adorton-adobe/sqlx"
-branch = "tokio-1.0"
+git = "https://github.com/launchbadge/sqlx"
+branch = "master"
+tag = "31abe22e348d6ac668c140de32612f0930c2abec"
 features = [ "runtime-tokio-native-tls", "sqlite" ]


### PR DESCRIPTION
## Summary
* Build sqlx from its official source repo at a known tag on master, rather than from a captive fork from a contributor repo.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #12 
