### PR TITLE
Separate port config options

### DIFF
--- a/src/proxy/plain.rs
+++ b/src/proxy/plain.rs
@@ -18,7 +18,8 @@ use crate::cache::Cache;
 use crate::settings::Settings;
 
 pub async fn run_server(conf: &Settings, cache: Arc<Cache>) -> Result<()> {
-    let addr: SocketAddr = conf.proxy.host.parse()?;
+    let full_host = format!("{}:{}", conf.proxy.host, conf.proxy.port);
+    let addr: SocketAddr = full_host.parse()?;
     info!("Listening on http://{}", addr);
     let make_svc = make_service_fn(move |_| {
         let conf = conf.clone();
@@ -40,7 +41,7 @@ pub async fn run_server(conf: &Settings, cache: Arc<Cache>) -> Result<()> {
     });
 
     // Run the server, keep going until an error occurs.
-    info!("Starting to serve on https://{}", conf.proxy.host);
+    info!("Starting to serve on http://{}", full_host);
     graceful.await.wrap_err("Unexpected server shutdown")?;
     Ok(())
 }

--- a/src/res/defaults.toml
+++ b/src/res/defaults.toml
@@ -1,6 +1,8 @@
 [proxy]
 mode = "cache"
-host = "0.0.0.0:8443"
+host = "0.0.0.0"
+port = "8000"
+ssl_port = "8443"
 remote_host = "https://lcs-cops.adobe.io"
 ssl = true
 

--- a/src/res/defaults.toml
+++ b/src/res/defaults.toml
@@ -1,7 +1,7 @@
 [proxy]
 mode = "cache"
 host = "0.0.0.0"
-port = "8000"
+port = "8080"
 ssl_port = "8443"
 remote_host = "https://lcs-cops.adobe.io"
 ssl = true

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -299,7 +299,7 @@ impl Settings {
             std::fs::metadata(path)
                 .wrap_err(format!("Invalid certificate path: {}", path))?;
         }
-        if self.proxy.host.contains(":") {
+        if self.proxy.host.contains(':') {
             return Err(eyre!("Host must not contain a port (use the 'port' and 'ssl_port' config options)"));
         }
         if let ProxyMode::Cache | ProxyMode::Store | ProxyMode::Forward = self.proxy.mode


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* New configuration options - `port` and `ssl_port`
* Port is no longer specified as part of `host`
* Configuration wizard prompts for `port` after asking for `host` IP and `ssl_port` only if SSL is enabled
* Running a plain (non-ssl) server uses `port` while SSL mode uses `ssl_port`

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
1. Run `start` in a directory with no config file
2. Specify host IP (no port)
3. Specify non-ssl port when prompted
4. Select "y" when asked to enable SSL
5. Specify ssl port when prompted
6. Run proxy in ssl mode, confirm that SSL port is in use
7. Run proxy in non-ssl mode, confirm that non-ssl port is in use
8. **Note**: I have not tested `configure` with a config that does not contain `port` or `ssl_port` already, but it should work

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #18 
