### PR TITLE
Fix issues with the service installation on Windows

### DIFF
--- a/external/win/service.ps1
+++ b/external/win/service.ps1
@@ -25,12 +25,21 @@ $serviceName = "FRL Online Proxy";
 
 switch ($cmd) {
     start {
-        $cfg = "$PSScriptRoot\proxy-conf.toml"
-        if (![System.IO.File]::Exists($cfg)) {
-            echo "Config file required";
+        $proxy = "$PSScriptRoot\frl-proxy.exe"
+        if (![System.IO.File]::Exists($proxy)) {
+            echo "You must place this script next to the proxy executable";
             exit 1;
         }
-        ./bin/nssm install $serviceName "$PSScriptRoot\frl-proxy.exe" "--config-file $cfg start";
+        $cfg = "$PSScriptRoot\proxy-conf.toml"
+        if (![System.IO.File]::Exists($cfg)) {
+            echo "You must have run frl-proxy configure before this script";
+            exit 1;
+        }
+        $stdout = "$PSScriptRoot\proxy-service-stdout.log"
+        $stderr = "$PSScriptRoot\proxy-service-stderr.log"
+        ./bin/nssm install $serviceName $proxy start;
+        ./bin/nssm set $serviceName AppStdout $stdout
+        ./bin/nssm set $serviceName AppStderr $stderr
         ./bin/nssm start $serviceName;
     }
     stop {

--- a/external/win/service.ps1
+++ b/external/win/service.ps1
@@ -1,6 +1,6 @@
 # MIT License
 
-# Copyright (c) 2020 Adobe, Inc.
+# Copyright (c) 2020-2022 Adobe, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,10 @@
 
 $cmd = $args[0];
 $serviceName = "FRL Online Proxy";
+$nssm = Join-Path (Join-Path $PSScriptRoot bin) nssm.exe
+if (![System.IO.File]::Exists($nssm)) {
+    echo "You must place this script next to the proxy executable and bin folder"
+}
 
 switch ($cmd) {
     start {
@@ -37,20 +41,20 @@ switch ($cmd) {
         }
         $stdout = "$PSScriptRoot\proxy-service-stdout.log"
         $stderr = "$PSScriptRoot\proxy-service-stderr.log"
-        ./bin/nssm install $serviceName $proxy start;
-        ./bin/nssm set $serviceName AppStdout $stdout
-        ./bin/nssm set $serviceName AppStderr $stderr
-        ./bin/nssm start $serviceName;
+        & $nssm install $serviceName $proxy start;
+        & $nssm set $serviceName AppStdout $stdout
+        & $nssm set $serviceName AppStderr $stderr
+        & $nssm start $serviceName;
     }
     stop {
-        ./bin/nssm stop $serviceName;
+        & $nssm stop $serviceName;
     }
     restart {
-        ./bin/nssm restart $serviceName;
+        & $nssm restart $serviceName;
     }
     remove {
-        ./bin/nssm stop $serviceName;
-        ./bin/nssm remove $serviceName confirm;
+        & $nssm stop $serviceName;
+        & $nssm remove $serviceName confirm;
     }
     Default {
         echo "Command (start, stop, restart, remove) is required.";


### PR DESCRIPTION
## Summary
* Fix reported problems with the service installation on Windows when the path to the proxy's directory has spaces in it.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Install the proxy into a directory that has a space in its name, such as `"C:\Users\you\frl proxy"`.
* Change into that directory
* Install and start the service by running `.\service.ps1 start`
* Check that a successful service start is reported.
* Check that both the `service-proxy-stdout.log` and `service-proxy-stderr.log` files are created and empty.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #30
